### PR TITLE
Refactored code to separate logic from Pot and UserPot, adding skelet…

### DIFF
--- a/src/app/core/services/pot.service.spec.ts
+++ b/src/app/core/services/pot.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { PotService } from './pot.service';
-import { CreatePotRequest, JoinPotRequest, Pot, JoinPotResponse, UserPot } from '@app/shared/models/pot.model';
+import { CreatePotRequest, Pot } from '@app/shared/models/pot.model';
 
 describe('PotService', () => {
   let service: PotService;
@@ -37,25 +37,6 @@ describe('PotService', () => {
     req.flush(mockResponse);
   });
 
-  it('should join a pot', () => {
-    const reqData: JoinPotRequest = { contractAddress: '0x123', walletAddress: '0xabc' };
-    const mockResponse: JoinPotResponse = {
-      potId: 1,
-      walletAddress: '0xabc',
-      joinedAt: new Date()
-    };
-
-    service.joinPot(reqData).subscribe(res => {
-      expect(res.potId).toBe(1);
-      expect(res.walletAddress).toBe('0xabc');
-      expect(res.joinedAt).toBeInstanceOf(Date);
-    });
-
-    const req = httpMock.expectOne('/api/pots/join');
-    expect(req.request.method).toBe('POST');
-    req.flush(mockResponse);
-  });
-
   it('should handle errors on createPot', () => {
     const reqData: CreatePotRequest = { contractAddress: '0xabc' };
 
@@ -70,19 +51,6 @@ describe('PotService', () => {
     req.flush('Error', { status: 500, statusText: 'Server Error' });
   });
 
-  it('should handle errors on joinPot', () => {
-    const reqData: JoinPotRequest = { contractAddress: '0x123', walletAddress: '0xabc' };
-
-    service.joinPot(reqData).subscribe({
-      next: () => fail('should have errored'),
-      error: (err) => {
-        expect(err.status).toBe(400);
-      }
-    });
-
-    const req = httpMock.expectOne('/api/pots/join');
-    req.flush('Error', { status: 400, statusText: 'Bad Request' });
-  });
 
   it('should get all pots', () => {
     const mockResponse: Pot[] = [
@@ -96,22 +64,6 @@ describe('PotService', () => {
     });
 
     const req = httpMock.expectOne('/api/pots');
-    expect(req.request.method).toBe('GET');
-    req.flush(mockResponse);
-  });
-
-  it('should get user pots', () => {
-    const userId = 'user1';
-    const mockResponse: UserPot[] = [
-      { userId, potId: 1 }
-    ];
-
-    service.getUserPots(userId).subscribe(res => {
-      expect(res.length).toBe(1);
-      expect(res[0].userId).toBe(userId);
-    });
-
-    const req = httpMock.expectOne(`/api/pots/user/${userId}`);
     expect(req.request.method).toBe('GET');
     req.flush(mockResponse);
   });

--- a/src/app/core/services/pot.service.ts
+++ b/src/app/core/services/pot.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, catchError, throwError } from 'rxjs';
-import { CreatePotRequest, JoinPotRequest, JoinPotResponse, Pot, UserPot } from '@app/shared/models/pot.model';
+import { CreatePotRequest, Pot } from '@app/shared/models/pot.model';
 
 @Injectable({
   providedIn: 'root'
@@ -17,21 +17,9 @@ export class PotService {
       .pipe(catchError(this.handleError));
   }
 
-  /** Join an existing pot */
-  joinPot(request: JoinPotRequest): Observable<JoinPotResponse> {
-    return this.http.post<JoinPotResponse>(`${this.baseUrl}/join`, request)
-      .pipe(catchError(this.handleError));
-  }
-
   /** Get all pots */
   getAllPots(): Observable<Pot[]> {
     return this.http.get<Pot[]>(this.baseUrl)
-      .pipe(catchError(this.handleError));
-  }
-
-  /** Get pots for a user */
-  getUserPots(userId: string): Observable<UserPot[]> {
-    return this.http.get<UserPot[]>(`${this.baseUrl}/user/${userId}`)
       .pipe(catchError(this.handleError));
   }
 

--- a/src/app/core/services/user-pot.service.spec.ts
+++ b/src/app/core/services/user-pot.service.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { UserPotService } from './user-pot.service';
+import { JoinPotRequest, JoinPotResponse, UserPot } from '@app/shared/models/user-pot.model';
+
+describe('PotService', () => {
+  let service: UserPotService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(UserPotService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should join a pot', () => {
+    const reqData: JoinPotRequest = { contractAddress: '0x123', walletAddress: '0xabc' };
+    const mockResponse: JoinPotResponse = {
+      potId: 1,
+      walletAddress: '0xabc',
+      joinedAt: new Date()
+    };
+
+    service.joinPot(reqData).subscribe(res => {
+      expect(res.potId).toBe(1);
+      expect(res.walletAddress).toBe('0xabc');
+      expect(res.joinedAt).toBeInstanceOf(Date);
+    });
+
+    const req = httpMock.expectOne('/api/pots/join');
+    expect(req.request.method).toBe('POST');
+    req.flush(mockResponse);
+  });
+
+
+  it('should handle errors on joinPot', () => {
+    const reqData: JoinPotRequest = { contractAddress: '0x123', walletAddress: '0xabc' };
+
+    service.joinPot(reqData).subscribe({
+      next: () => fail('should have errored'),
+      error: (err) => {
+        expect(err.status).toBe(400);
+      }
+    });
+
+    const req = httpMock.expectOne('/api/pots/join');
+    req.flush('Error', { status: 400, statusText: 'Bad Request' });
+  });
+
+  it('should get user pots', () => {
+    const userId = 'user1';
+    const mockResponse: UserPot[] = [
+      { userId, potId: 1 }
+    ];
+
+    service.getUserPots(userId).subscribe(res => {
+      expect(res.length).toBe(1);
+      expect(res[0].userId).toBe(userId);
+    });
+
+    const req = httpMock.expectOne(`/api/pots/user/${userId}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+});

--- a/src/app/core/services/user-pot.service.ts
+++ b/src/app/core/services/user-pot.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, catchError, throwError } from 'rxjs';
+import { JoinPotRequest, JoinPotResponse, UserPot } from '@app/shared/models/user-pot.model';
+@Injectable({
+  providedIn: 'root'
+})
+export class UserPotService {
+  private baseUrl = '/api/user'; // Will resolve to localhost:8080 via proxy
+
+  constructor(private http: HttpClient) {}
+
+    /** Join an existing pot */
+    joinPot(request: JoinPotRequest): Observable<JoinPotResponse> {
+      return this.http.post<JoinPotResponse>(`${this.baseUrl}/join`, request)
+        .pipe(catchError(this.handleError));
+    }
+
+  //getPotList
+
+   /** Get pots for a user */
+  getUserPots(userId: string): Observable<UserPot[]> {
+    return this.http.get<UserPot[]>(`${this.baseUrl}/user/${userId}`)
+      .pipe(catchError(this.handleError));
+  }
+
+   /** Error handler */
+    private handleError(error: any) {
+      // Optionally log to remote server
+      return throwError(() => error);
+    }
+}

--- a/src/app/pages/user/user-profile/user-profile.component.html
+++ b/src/app/pages/user/user-profile/user-profile.component.html
@@ -3,3 +3,9 @@
   <join-pot-btn [userAddress]="userAddress"></join-pot-btn>
   <p *ngIf="message" class="error-message">{{ message }}</p>
 </div>
+<div>
+    <app-wallet-connect (connected)="userAddress = $event"></app-wallet-connect>
+
+    //component for displaying the users joined pools
+    <pot-preview></pot-preview>
+</div>

--- a/src/app/shared/component/buttons/join-pot-btn/join-pot-btn.component.ts
+++ b/src/app/shared/component/buttons/join-pot-btn/join-pot-btn.component.ts
@@ -1,10 +1,10 @@
 import { Component, Input } from '@angular/core';
 import { Web3Service } from '@app/core/web3.service';
-import { PotService } from '@app/core/services/pot.service';
+import { UserPotService } from '@app/core/services/user-pot.service';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { WalletConnectComponent } from '@app/shared/component/wallet-connect/wallet-connect.component';
-import { JoinPotRequest } from '@app/shared/models/pot.model';
+import { JoinPotRequest } from '@app/shared/models/user-pot.model';
 
 @Component({
   selector: 'join-pot-btn',
@@ -20,7 +20,10 @@ export class JoinPotBtnComponent {
   connecting = false;
   message = '';
 
-  constructor(private web3: Web3Service, private potService: PotService) {}
+  constructor(
+    private web3: Web3Service,
+    private userPotService: UserPotService
+  ) {}
 
   async ngOnInit() {
     if (!this.userAddress) {
@@ -54,8 +57,8 @@ export class JoinPotBtnComponent {
         contractAddress: this.contractAddress,
         walletAddress: this.userAddress!,
       };
-
-      this.potService.joinPot(joinRequest).subscribe({
+      
+      this.userPotService.joinPot(joinRequest).subscribe({
         next: (response) => {
           this.message = '✅ Joined the pot! Backend updated successfully.';
           console.log('Backend response:', response);

--- a/src/app/shared/component/display/pot-preview/pot-preview.component.html
+++ b/src/app/shared/component/display/pot-preview/pot-preview.component.html
@@ -1,0 +1,4 @@
+<div>  
+    <h2>Join Pot {{ contractAddress }}</h2>
+    <join-pot-btn [userAddress]="userAddress" [contractAddress]="contractAddress"></join-pot-btn>
+</div>

--- a/src/app/shared/component/display/pot-preview/pot-preview.component.spec.ts
+++ b/src/app/shared/component/display/pot-preview/pot-preview.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PotPreviewComponent } from './pot-preview.component';
+
+describe('PotPreviewComponent', () => {
+  let component: PotPreviewComponent;
+  let fixture: ComponentFixture<PotPreviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PotPreviewComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(PotPreviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/component/display/pot-preview/pot-preview.component.ts
+++ b/src/app/shared/component/display/pot-preview/pot-preview.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { JoinPotBtnComponent } from '@app/shared/component/buttons/join-pot-btn/join-pot-btn.component';
+
+@Component({
+  selector: 'pot-preview',
+  standalone: true,
+  imports: [JoinPotBtnComponent],
+  templateUrl: './pot-preview.component.html',
+  styleUrl: './pot-preview.component.scss'
+})
+export class PotPreviewComponent {
+  @Input() userAddress: string = '';
+  @Input() contractAddress: string = '';
+}

--- a/src/app/shared/models/pot.model.ts
+++ b/src/app/shared/models/pot.model.ts
@@ -2,25 +2,8 @@ export interface CreatePotRequest {
   contractAddress: string;
 }
 
-export interface JoinPotRequest {
-  contractAddress: string;
-  walletAddress: string;
-}
-
-export interface JoinPotResponse {
-  potId: number;
-  walletAddress: string;
-  joinedAt: Date; 
-}
-
 export interface Pot {
   id: number;
   contractAddress: string;
   // Extend with any backend-returned fields
-}
-
-export interface UserPot {
-  userId: string;
-  potId: number;
-  // Extend with real response
 }

--- a/src/app/shared/models/user-pot.model.ts
+++ b/src/app/shared/models/user-pot.model.ts
@@ -1,0 +1,20 @@
+export interface JoinPotRequest {
+  contractAddress: string;
+  walletAddress: string;
+}
+
+export interface JoinPotResponse {
+  potId: number;
+  walletAddress: string;
+  joinedAt: Date; 
+}
+
+//getListRequest
+
+//getListResponse
+
+export interface UserPot {
+  userId: string;
+  potId: number;
+  // Extend with real response
+}


### PR DESCRIPTION
UserPot and Pot logic to be seperated
- Pot logic should be about interactions with the pots. ie create pot, get list of pots etc
- UserPot logic is the crossover of users interacting with the pots, joining pot, get list of pots that a user has joined

Creating skeleton for displaying all pots for a user